### PR TITLE
fix default kafka request serializer

### DIFF
--- a/src/serializer/kafka-request.serializer.ts
+++ b/src/serializer/kafka-request.serializer.ts
@@ -15,21 +15,6 @@ export interface KafkaRequest<T = any> {
 
 export class KafkaRequestSerializer implements Serializer<any, KafkaRequest> {
   serialize(value: any): KafkaRequest {
-    const isNotKafkaMessage =
-      isNil(value) ||
-      !isObject(value) ||
-      (!('key' in value) && !('value' in value));
-
-    if (isNotKafkaMessage) {
-      value = { value };
-    }
-    value.value = this.encode(value.value);
-    if (!isNil(value.key)) {
-      value.key = this.encode(value.key);
-    }
-    if (isNil(value.headers)) {
-      value.headers = {};
-    }
     return value;
   }
 


### PR DESCRIPTION
Some strange behavior I came across today, is I left every to it's default, when I try to send a kafka request I get the error:
```
INVALID_TOPC
```
I'm not sure if it's something I done wrong in my code, this is a piece from my code I used to produce the message:
```ts
@Injectable()
export class MessageBrokerProducerService {
  constructor(@Inject('SERVICE_NAME') private client: KafkaService) {}

  public async produce(topic: string, key: string, data: object) {
    const message: KafkaMessageSend = {
      topic: topic,
      messages: [
        {
          key: key,
          value: JSON.stringify(data),
        },
      ],
    };
    return this.client.send(message);
  }
}
```
and this is my module configuration:

```ts
KafkaModule.register([
      {
        name: 'SERVICE_NAME',
        options: {
          client: {
            clientId: MessageBrokerConfig.CLIENT_ID,
            brokers: [Config.KAFKA_BROKER],
          },
          consumer: {
            groupId: MessageBrokerConfig.GROUP_ID,
            allowAutoTopicCreation: true,
          },
          producer: {
            allowAutoTopicCreation: true,
          },
        },
      },
    ]),
```
When I investigated where the problem is I found out that the *send* method on ***kafka** producer* object is is defined as:
```js
const send = async ({ acks, timeout, compression, topic, messages }) => {
    const topicMessage = { topic, messages }
    return sendBatch({
      acks,
      timeout,
      compression,
      topicMessages: [topicMessage],
    })
  }
```
while the ***KafkaRequestSerializer*** serializes the request as :
```js
{
      value:"{topic:'my_topic', messages:[{key:'my-key',value:'my-value'}] ...",
      headers:{}
}
```

and since kafkajs tries to destruct returned value from ***KafkaRequestSerializer*** to 
```
{ acks, timeout, compression, topic, messages }
```
it fails because topic or message don't exist in returned object after ***KafkaRequestSerializer*** serialization, as a result kafkajs throws **INVALID_TOPC** error.
I removed the serialization content from *serialize* method in ***KafkaRequestSerializer*** as a temporary solution, and I hope you fix this soon or merge this branch, as this may break apps in production.
I'm using 
```
"@rob3000/nestjs-kafka": "^1.4.1",
```